### PR TITLE
Updated to support SSL.

### DIFF
--- a/jobs/bitcoin.rb
+++ b/jobs/bitcoin.rb
@@ -5,6 +5,7 @@ require 'uri'
 SCHEDULER.every '5s' do
   uri = URI.parse('https://api.coinbase.com/v2/prices/BTC-USD/spot')
   http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true
   request = Net::HTTP::Get.new(uri.request_uri)
   response = http.request(request)
   json_response = JSON.parse(response.body)


### PR DESCRIPTION
In order for this job to work properly, `http.use_ssl = true` needs to be added.